### PR TITLE
Sync fork with original repo

### DIFF
--- a/config/vda5050_connector.yaml
+++ b/config/vda5050_connector.yaml
@@ -32,3 +32,8 @@ subscribe_topics:
     information: "/information"                             # Information messages from the robot
     safety_state: "/safety_state"                           # Robot's safety state
     interaction_zones: "/interaction_zones"                 # State of the interaction zones.
+
+publish_periods:
+    state_msg: 0.8                                          # Period on which to send state message if no new triggers
+    visualization_msg: 0.3                                  # Period on which to send visualization message
+    conn_msg: 15.0                                          # Period on which to send connection message

--- a/include/models/State.h
+++ b/include/models/State.h
@@ -122,7 +122,7 @@ class State {
    *
    * @param timestamp
    */
-  inline void SetTimestamp(const std::string& timestamp) { state.timeStamp = timestamp; }
+  inline void SetTimestamp(const std::string& timestamp) { state.timestamp = timestamp; }
 
   /**
    * @brief Set the Manufacturer field in the message header.

--- a/src/mock_ups/action_msg_mockup.cpp
+++ b/src/mock_ups/action_msg_mockup.cpp
@@ -66,7 +66,7 @@ void send_instant_action(ros::Publisher* pub) {
   instAction.headerId = 123456;
   instAction.manufacturer = "AGV";
   instAction.serialNumber = "";
-  instAction.timeStamp = "";
+  instAction.timestamp = "";
   instAction.version = "v1.0";
 
   msg1.actionId = uuid::generate_uuid_v4();
@@ -86,8 +86,8 @@ void send_instant_action(ros::Publisher* pub) {
   msg1.actionParameters.push_back(param1);
   msg2.actionParameters.push_back(param2);
 
-  instAction.instantActions.push_back(msg1);
-  instAction.instantActions.push_back(msg2);
+  instAction.actions.push_back(msg1);
+  instAction.actions.push_back(msg2);
 
   pub->publish(instAction);
   ROS_INFO_STREAM("New instant action sent!");

--- a/src/mock_ups/order_mockup/dummy_msg_creator.cpp
+++ b/src/mock_ups/order_mockup/dummy_msg_creator.cpp
@@ -128,7 +128,7 @@ void OrderMsg::create_example_order(int new_headerId, std::string new_orderId, i
     int node_num, int node_released_num) {
   // header
   this->_msg.headerId = new_headerId;
-  this->_msg.timeStamp = "10/6/2022 10:16:37 AM";
+  this->_msg.timestamp = "10/6/2022 10:16:37 AM";
   this->_msg.version = "v1";
   this->_msg.manufacturer;
   this->_msg.serialNumber;

--- a/src/mock_ups/order_msg_mockup.cpp
+++ b/src/mock_ups/order_msg_mockup.cpp
@@ -159,7 +159,7 @@ vda5050_msgs::Edge createEdge() {
 vda5050_msgs::Order createMessage() {
   vda5050_msgs::Order orderMsg;
   orderMsg.headerId = 1;
-  orderMsg.timeStamp = getTimestamp();
+  orderMsg.timestamp = getTimestamp();
   orderMsg.version = "1.1";
   orderMsg.manufacturer = "fml Enterprise";
   orderMsg.serialNumber = "ajf894ajc";

--- a/src/models/State.cpp
+++ b/src/models/State.cpp
@@ -1,6 +1,10 @@
 #include "models/State.h"
 
-State::State() { this->state = vda5050_msgs::State(); }
+State::State() {
+  this->state = vda5050_msgs::State();
+  this->state.operatingMode = vda5050_msgs::State::MANUAL;
+  this->state.safetyState.eStop = vda5050_msgs::SafetyState::NONE;
+}
 
 vda5050_msgs::NodeState State::NodeToNodeState(const vda5050_msgs::Node& n) {
   vda5050_msgs::NodeState ns;

--- a/src/vda5050_connector/action_client.cpp
+++ b/src/vda5050_connector/action_client.cpp
@@ -553,9 +553,12 @@ int main(int argc, char** argv) {
 
   ActionClient ActionClient;
 
+  ros::Rate rate(0.05);
+
   while (ros::ok()) {
     ActionClient.UpdateActions();
     ros::spinOnce();
+    rate.sleep();
   }
   return 0;
 }

--- a/src/vda5050_connector/action_client.cpp
+++ b/src/vda5050_connector/action_client.cpp
@@ -111,7 +111,7 @@ void ActionClient::OrderCancelCallback(const std_msgs::String& msg) {
 
 void ActionClient::InstantActionsCallback(const vda5050_msgs::InstantAction::ConstPtr& msg) {
   // Iterate over all actions in the instantActions msg
-  for (auto& iaction : msg->instantActions) {
+  for (auto& iaction : msg->actions) {
     // Add action to active actions list
     ActionClient::AddActionToList(&iaction, "Instant", "WAITING");
     // Initialize order ID variable

--- a/src/vda5050_connector/vda5050_connector.cpp
+++ b/src/vda5050_connector/vda5050_connector.cpp
@@ -50,9 +50,9 @@ VDA5050Connector::VDA5050Connector() : state(State()), order(Order()) {
     ROS_ERROR("%s not found in the configuration!", SN_PARAM);
   }
 
-  stateTimer = nh.createTimer(ros::Duration(3.0), std::bind(&VDA5050Connector::PublishState, this));
+  stateTimer = nh.createTimer(ros::Duration(0.8), std::bind(&VDA5050Connector::PublishState, this));
   visTimer =
-      nh.createTimer(ros::Duration(1.0), std::bind(&VDA5050Connector::PublishVisualization, this));
+      nh.createTimer(ros::Duration(0.3), std::bind(&VDA5050Connector::PublishVisualization, this));
   connTimer = nh.createTimer(
       ros::Duration(15.0), std::bind(&VDA5050Connector::PublishConnection, this, true));
   newPublishTrigger = true;

--- a/src/vda5050_connector/vda5050_connector.cpp
+++ b/src/vda5050_connector/vda5050_connector.cpp
@@ -50,11 +50,18 @@ VDA5050Connector::VDA5050Connector() : state(State()), order(Order()) {
     ROS_ERROR("%s not found in the configuration!", SN_PARAM);
   }
 
-  stateTimer = nh.createTimer(ros::Duration(0.8), std::bind(&VDA5050Connector::PublishState, this));
-  visTimer =
-      nh.createTimer(ros::Duration(0.3), std::bind(&VDA5050Connector::PublishVisualization, this));
+  ros::NodeHandle private_nh("~");
+  double stateMsgPeriod, visMsgPeriod, connMsgPeriod;
+  private_nh.param<double>("publish_periods/state_msg", stateMsgPeriod, 0.8);
+  private_nh.param<double>("publish_periods/visualization_msg", visMsgPeriod, 0.3);
+  private_nh.param<double>("publish_periods/conn_msg", connMsgPeriod, 15.0);
+
+  stateTimer = nh.createTimer(
+      ros::Duration(stateMsgPeriod), std::bind(&VDA5050Connector::PublishState, this));
+  visTimer = nh.createTimer(
+      ros::Duration(visMsgPeriod), std::bind(&VDA5050Connector::PublishVisualization, this));
   connTimer = nh.createTimer(
-      ros::Duration(15.0), std::bind(&VDA5050Connector::PublishConnection, this, true));
+      ros::Duration(connMsgPeriod), std::bind(&VDA5050Connector::PublishConnection, this, true));
   newPublishTrigger = true;
 }
 

--- a/src/vda5050_connector/vda5050_connector.cpp
+++ b/src/vda5050_connector/vda5050_connector.cpp
@@ -413,7 +413,7 @@ void VDA5050Connector::PublishVisualization() {
   auto vis = state.CreateVisualizationMsg();
 
   // Set the header fields.
-  vis.timeStamp = connector_utils::GetISOCurrentTimestamp();
+  vis.timestamp = connector_utils::GetISOCurrentTimestamp();
   vis.headerId = visHeaderId;
 
   visPublisher.publish(vis);
@@ -428,7 +428,7 @@ void VDA5050Connector::PublishConnection(const bool connected) {
 
   // Set the header fields.
   connection.headerId = connHeaderId;
-  connection.timeStamp = connector_utils::GetISOCurrentTimestamp();
+  connection.timestamp = connector_utils::GetISOCurrentTimestamp();
   connection.version = state.GetVersion();
   connection.manufacturer = state.GetManufacturer();
   connection.serialNumber = state.GetSerialNumber();


### PR DESCRIPTION
This pull request includes several important changes to improve the consistency of field names, add new configuration options, and enhance the functionality of the `VDA5050Connector` class. The most important changes are listed below:

Field name consistency:
* Updated `timeStamp` to `timestamp` across multiple files to maintain consistency (`include/models/State.h`, `src/mock_ups/action_msg_mockup.cpp`, `src/mock_ups/order_mockup/dummy_msg_creator.cpp`, `src/mock_ups/order_msg_mockup.cpp`, `src/vda5050_connector/vda5050_connector.cpp`). [[1]](diffhunk://#diff-acb691aa726ad28c6a417c61ff44d51232857a9ebe9e8ce544ee5f861f54c2b7L125-R125) [[2]](diffhunk://#diff-f0166dd6062bdc8fc45904c8526157d29ee4af3a863fe3bf84b0a5429f3cb096L69-R69) [[3]](diffhunk://#diff-94c8b49e034ef462c3a350821e8d52f1a5c22974fdc2310e48ef07a6d4cfeb30L131-R131) [[4]](diffhunk://#diff-f5713e336bc09cade02284105740f4d3f6577b18c31f02084fa3776e6f10e6b4L162-R162) [[5]](diffhunk://#diff-c7145e01931c1dc735e8f23137023d50d1f5363dfcb09ffc4e1a676e4b8d9f2bL409-R416) [[6]](diffhunk://#diff-c7145e01931c1dc735e8f23137023d50d1f5363dfcb09ffc4e1a676e4b8d9f2bL424-R431)

Configuration enhancements:
* Added `publish_periods` configuration options in `config/vda5050_connector.yaml` to specify the periods for sending different types of messages (`state_msg`, `visualization_msg`, `conn_msg`).

Codebase improvements:
* Modified `VDA5050Connector` class to use the new `publish_periods` configuration options for setting timer durations (`src/vda5050_connector/vda5050_connector.cpp`).

Functionality enhancements:
* Added default values for `operatingMode` and `safetyState.eStop` in the `State` constructor (`src/models/State.cpp`).
* Added a sleep rate to the main loop in `action_client.cpp` to control the frequency of action updates (`src/vda5050_connector/action_client.cpp`).

These changes collectively improve the consistency, configurability, and functionality of the codebase.